### PR TITLE
fix: Read reconciliation timeout from configmap

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -448,6 +448,28 @@ func getArgoControllerContainerEnv(cr *argoprojv1a1.ArgoCD) []corev1.EnvVar {
 		})
 	}
 
+	env = append(env, corev1.EnvVar{
+		Name: "ARGOCD_RECONCILIATION_TIMEOUT",
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+				Key:                  "timeout.reconciliation",
+				Optional:             boolPtr(true),
+			},
+		},
+	})
+
+	env = append(env, corev1.EnvVar{
+		Name: "ARGOCD_HARD_RECONCILIATION_TIMEOUT",
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+				Key:                  "timeout.hard.reconciliation",
+				Optional:             boolPtr(true),
+			},
+		},
+	})
+
 	return env
 }
 

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -311,6 +311,20 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			},
 			replicas: 1,
 			vars: []corev1.EnvVar{
+				{Name: "ARGOCD_HARD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.hard.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
+				{Name: "ARGOCD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 			},
 		},
@@ -322,6 +336,20 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 1,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "1"},
+				{Name: "ARGOCD_HARD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.hard.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
+				{Name: "ARGOCD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 			},
 		},
@@ -333,6 +361,20 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 3,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "3"},
+				{Name: "ARGOCD_HARD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.hard.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
+				{Name: "ARGOCD_RECONCILIATION_TIMEOUT", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "argocd-cm"},
+						Key:                  "timeout.reconciliation",
+						Optional:             boolPtr(true),
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:

We encountered an issue where the reconciliation timeout setting in the `argocd-cm` configmap was not being correctly applied to the controller, despite being documented as such. After some investigation, we discovered that the `argocd-operator` was not reading the values for `timeout.reconciliation` and `timeout.hard.reconciliation` from the `argocd-cm` configmap. This only works, when using the Helm chart as seen here: https://github.com/argoproj/argo-helm/blob/2538371fecba8e3bc7a161f6484e3d752f71d1e1/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml#L107

To address this issue, this PR has been submitted, which introduces the same logic for `ARGOCD_RECONCILIATION_TIMEOUT` and `ARGOCD_HARD_RECONCILIATION_TIMEOUT` to the `argocd-operator`. This will ensure that the `argocd-operator` is capable of reading and applying the reconciliation timeout settings from the `argocd-cm` configmap, aligning it with the behavior of the Helm chart.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

We found similar issues in the `argo-cd` repository https://github.com/argoproj/argo-cd/issues/11995. We are not sure though if they are using the `argocd-operator` as well.

**How to test changes / Special notes to the reviewer**:

Set the `timeout.reconciliation` value to 1 minute in the `argocd-cm` configmap and verify that the controller performs reconciliation every minute instead of the default 3 minutes.
